### PR TITLE
Narwhal consensus: Part 2

### DIFF
--- a/blockchain/chain_sync/src/chain_muxer.rs
+++ b/blockchain/chain_sync/src/chain_muxer.rs
@@ -40,7 +40,7 @@ use thiserror::Error;
 use std::sync::Arc;
 use std::time::SystemTime;
 
-pub(crate) type WorkerState = Arc<RwLock<SyncState>>;
+pub type WorkerState = Arc<RwLock<SyncState>>;
 
 type ChainMuxerFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send>>;
 
@@ -175,6 +175,7 @@ where
         genesis: Arc<Tipset>,
         tipset_sender: Sender<Arc<Tipset>>,
         tipset_receiver: Receiver<Arc<Tipset>>,
+        worker_state: WorkerState,
         cfg: SyncConfig,
     ) -> Result<Self, ChainMuxerError<C>> {
         let network = SyncNetworkContext::new(
@@ -185,7 +186,7 @@ where
 
         Ok(Self {
             state: ChainMuxerState::Idle,
-            worker_state: Default::default(),
+            worker_state,
             network,
             genesis,
             consensus,

--- a/blockchain/chain_sync/src/consensus.rs
+++ b/blockchain/chain_sync/src/consensus.rs
@@ -47,6 +47,18 @@ pub trait Consensus: Scale + Debug + Send + Sync + Unpin + 'static {
     ) -> Result<(), NonEmpty<Self::Error>>
     where
         DB: BlockStore + Sync + Send + 'static;
+
+    /// Indicate whether this consensus requires blocks to be signed.
+    ///
+    /// One use case where we can't have signatures is when nodes derive blocks in a deterministic
+    /// fashion from an already ordered stream of transactions. Under this scenario signatures might
+    /// be gossiped around later, but they aren't part of the block.
+    ///
+    /// The reason different nodes can't add different signatures to their individual blocks is because
+    /// 1) the would not be able to sign in the name of the miner who should get the rewards
+    /// 2) the signature becomes part of the block CID (just not the `to_signing_bytes`),
+    ///    so everyone would have different keys in their tipsets
+    fn requires_block_signature() -> bool;
 }
 
 /// Helper function to collect errors from async validations.

--- a/blockchain/chain_sync/src/consensus.rs
+++ b/blockchain/chain_sync/src/consensus.rs
@@ -60,12 +60,15 @@ pub trait Consensus: Scale + Debug + Send + Sync + Unpin + 'static {
     /// 1) the would not be able to sign in the name of the miner who should get the rewards
     /// 2) the signature becomes part of the block CID (just not the `to_signing_bytes`),
     ///    so everyone would have different keys in their tipsets
-    fn requires_block_signature() -> bool;
+    const REQUIRE_MINER_SIGNATURE: bool;
 
     /// Indicate whether the `epoch` has relation to time and `block_delay`.
     ///
     /// If not, then we cannot compare epoch to the wall clock time to estimate maximum chain growth.
-    fn time_based_epoch() -> bool;
+    const ENFORCE_EPOCH_DELAY: bool;
+
+    /// Should the block be rejected if the global `BLOCK_GAS_LIMIT` is violated.
+    const ENFORCE_BLOCK_GAS_LIMIT: bool;
 }
 
 /// Helper function to collect errors from async validations.

--- a/blockchain/chain_sync/src/consensus.rs
+++ b/blockchain/chain_sync/src/consensus.rs
@@ -59,6 +59,11 @@ pub trait Consensus: Scale + Debug + Send + Sync + Unpin + 'static {
     /// 2) the signature becomes part of the block CID (just not the `to_signing_bytes`),
     ///    so everyone would have different keys in their tipsets
     fn requires_block_signature() -> bool;
+
+    /// Indicate whether the `epoch` has relation to time and `block_delay`.
+    ///
+    /// If not, then we cannot compare epoch to the wall clock time to estimate maximum chain growth.
+    fn time_based_epoch() -> bool;
 }
 
 /// Helper function to collect errors from async validations.

--- a/blockchain/chain_sync/src/lib.rs
+++ b/blockchain/chain_sync/src/lib.rs
@@ -14,7 +14,7 @@ mod tipset_syncer;
 mod validation;
 
 pub use self::bad_block_cache::BadBlockCache;
-pub use self::chain_muxer::{ChainMuxer, SyncConfig};
+pub use self::chain_muxer::{ChainMuxer, SyncConfig, WorkerState};
 pub use self::consensus::{collect_errs, Consensus};
 pub use self::sync_state::{SyncStage, SyncState};
 pub use self::validation::TipsetValidator;

--- a/blockchain/chain_sync/src/tipset_syncer.rs
+++ b/blockchain/chain_sync/src/tipset_syncer.rs
@@ -1334,7 +1334,10 @@ async fn validate_block<DB: BlockStore + Sync + Send + 'static, C: Consensus>(
     // Block signature check
     let v_block = block.clone();
     validations.push(task::spawn_blocking(move || {
-        v_block.header().check_block_signature(&work_addr)?;
+        // Sanity checking already ensured that the signature is either present, or it's acceptable not to be.
+        if v_block.header().signature().is_some() {
+            v_block.header().check_block_signature(&work_addr)?;
+        }
         Ok(())
     }));
 
@@ -1535,9 +1538,11 @@ fn check_block_messages<DB: BlockStore + Send + Sync + 'static, C: Consensus>(
 fn block_sanity_checks<C: Consensus>(
     header: &BlockHeader,
 ) -> Result<(), TipsetRangeSyncerError<C>> {
-    if header.signature().is_none() {
+    if header.signature().is_none() && C::requires_block_signature() {
         return Err(TipsetRangeSyncerError::BlockWithoutSignature);
     }
+    // The BLS aggregate is based on the signed messages, so there can always be something.
+    // If there are no BLS messages it's supposed to contain some empty bytes.
     if header.bls_aggregate().is_none() {
         return Err(TipsetRangeSyncerError::BlockWithoutBlsAggregate);
     }

--- a/blockchain/chain_sync/src/tipset_syncer.rs
+++ b/blockchain/chain_sync/src/tipset_syncer.rs
@@ -1445,7 +1445,7 @@ fn check_block_messages<DB: BlockStore + Send + Sync + 'static, C: Consensus>(
         valid_for_block_inclusion(msg, min_gas.total(), network_version)
             .map_err(|e| anyhow::anyhow!("{}", e))?;
         sum_gas_limit += msg.gas_limit;
-        if sum_gas_limit > BLOCK_GAS_LIMIT {
+        if sum_gas_limit > BLOCK_GAS_LIMIT && C::ENFORCE_BLOCK_GAS_LIMIT {
             anyhow::bail!("block gas limit exceeded");
         }
 
@@ -1538,7 +1538,7 @@ fn check_block_messages<DB: BlockStore + Send + Sync + 'static, C: Consensus>(
 fn block_sanity_checks<C: Consensus>(
     header: &BlockHeader,
 ) -> Result<(), TipsetRangeSyncerError<C>> {
-    if header.signature().is_none() && C::requires_block_signature() {
+    if header.signature().is_none() && C::REQUIRE_MINER_SIGNATURE {
         return Err(TipsetRangeSyncerError::BlockWithoutSignature);
     }
     // The BLS aggregate is based on the signed messages, so there can always be something.

--- a/blockchain/chain_sync/src/validation.rs
+++ b/blockchain/chain_sync/src/validation.rs
@@ -72,7 +72,7 @@ impl<'a> TipsetValidator<'a> {
         }
 
         // Tipset epoch must not be behind current max
-        if C::time_based_epoch() {
+        if C::ENFORCE_EPOCH_DELAY {
             self.validate_epoch(genesis_tipset, block_delay)?;
         }
 

--- a/blockchain/chain_sync/src/validation.rs
+++ b/blockchain/chain_sync/src/validation.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 
 use crate::bad_block_cache::BadBlockCache;
+use crate::Consensus;
 
 use cid::{multihash::Code::Blake2b256, Cid};
 use forest_blocks::{Block, FullTipset, Tipset, TxMeta};
@@ -54,20 +55,26 @@ impl From<EncodingError> for TipsetValidationError {
 pub struct TipsetValidator<'a>(pub &'a FullTipset);
 
 impl<'a> TipsetValidator<'a> {
-    pub async fn validate<DB: BlockStore + Send + Sync + 'static>(
+    pub async fn validate<DB, C>(
         &self,
         chainstore: Arc<ChainStore<DB>>,
         bad_block_cache: Arc<BadBlockCache>,
         genesis_tipset: Arc<Tipset>,
         block_delay: u64,
-    ) -> Result<(), TipsetValidationError> {
+    ) -> Result<(), TipsetValidationError>
+    where
+        DB: BlockStore + Send + Sync + 'static,
+        C: Consensus,
+    {
         // No empty blocks
         if self.0.blocks().is_empty() {
             return Err(TipsetValidationError::NoBlocks);
         }
 
         // Tipset epoch must not be behind current max
-        self.validate_epoch(genesis_tipset, block_delay)?;
+        if C::time_based_epoch() {
+            self.validate_epoch(genesis_tipset, block_delay)?;
+        }
 
         // Validate each block in the tipset by:
         // 1. Calculating the message root using all of the messages to ensure it matches the mst root in the block header
@@ -82,7 +89,7 @@ impl<'a> TipsetValidator<'a> {
         Ok(())
     }
 
-    pub fn validate_epoch(
+    fn validate_epoch(
         &self,
         genesis_tipset: Arc<Tipset>,
         block_delay: u64,
@@ -100,7 +107,7 @@ impl<'a> TipsetValidator<'a> {
         }
     }
 
-    pub fn validate_msg_root<DB: BlockStore>(
+    fn validate_msg_root<DB: BlockStore>(
         &self,
         blockstore: &DB,
         block: &Block,

--- a/blockchain/consensus/deleg_cns/src/composition.rs
+++ b/blockchain/consensus/deleg_cns/src/composition.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0, MIT
 use crate::DelegatedConsensus;
 use async_std::{sync::RwLock, task::JoinHandle};
-use forest_chain_sync::consensus::{MessagePoolApi, Proposer, SyncGossipSubmitter};
+use forest_chain_sync::{
+    consensus::{MessagePoolApi, Proposer, SyncGossipSubmitter},
+    WorkerState,
+};
 use forest_ipld_blockstore::BlockStore;
 use forest_key_management::KeyStore;
 use forest_state_manager::StateManager;
@@ -29,6 +32,7 @@ pub async fn consensus<DB, MP>(
     keystore: &Arc<RwLock<KeyStore>>,
     mpool: &Arc<MP>,
     submitter: SyncGossipSubmitter,
+    sync_state: WorkerState,
 ) -> anyhow::Result<(FullConsensus, Vec<MiningTask>)>
 where
     DB: BlockStore + Send + Sync + 'static,
@@ -39,7 +43,7 @@ where
         info!("Starting the delegated consensus proposer...");
         let sm = state_manager.clone();
         let mp = mpool.clone();
-        let mining_tasks = proposer.spawn(sm, mp, submitter).await?;
+        let mining_tasks = proposer.spawn(sm, mp, submitter, sync_state).await?;
         Ok((consensus, mining_tasks))
     } else {
         Ok((consensus, vec![]))

--- a/blockchain/consensus/deleg_cns/src/composition.rs
+++ b/blockchain/consensus/deleg_cns/src/composition.rs
@@ -15,6 +15,7 @@ type MiningTask = JoinHandle<()>;
 pub type FullConsensus = DelegatedConsensus;
 
 pub const FETCH_PARAMS: bool = false;
+pub const PUBLISH_MSG: bool = true;
 
 // Reward 1FIL on top of the gas, which is what Eudico does.
 pub fn reward_calc() -> Arc<dyn forest_interpreter::RewardCalc> {

--- a/blockchain/consensus/deleg_cns/src/consensus.rs
+++ b/blockchain/consensus/deleg_cns/src/consensus.rs
@@ -142,4 +142,8 @@ impl Consensus for DelegatedConsensus {
     fn requires_block_signature() -> bool {
         true
     }
+
+    fn time_based_epoch() -> bool {
+        true
+    }
 }

--- a/blockchain/consensus/deleg_cns/src/consensus.rs
+++ b/blockchain/consensus/deleg_cns/src/consensus.rs
@@ -138,4 +138,8 @@ impl Consensus for DelegatedConsensus {
             .await
             .map_err(NonEmpty::new)
     }
+
+    fn requires_block_signature() -> bool {
+        true
+    }
 }

--- a/blockchain/consensus/deleg_cns/src/consensus.rs
+++ b/blockchain/consensus/deleg_cns/src/consensus.rs
@@ -126,6 +126,10 @@ impl Scale for DelegatedConsensus {
 impl Consensus for DelegatedConsensus {
     type Error = DelegatedConsensusError;
 
+    const REQUIRE_MINER_SIGNATURE: bool = true;
+    const ENFORCE_EPOCH_DELAY: bool = true;
+    const ENFORCE_BLOCK_GAS_LIMIT: bool = true;
+
     async fn validate_block<DB>(
         &self,
         state_manager: Arc<StateManager<DB>>,
@@ -137,13 +141,5 @@ impl Consensus for DelegatedConsensus {
         crate::validation::validate_block(&self.chosen_one, state_manager, block)
             .await
             .map_err(NonEmpty::new)
-    }
-
-    fn requires_block_signature() -> bool {
-        true
-    }
-
-    fn time_based_epoch() -> bool {
-        true
     }
 }

--- a/blockchain/consensus/deleg_cns/src/proposer.rs
+++ b/blockchain/consensus/deleg_cns/src/proposer.rs
@@ -150,7 +150,7 @@ impl DelegatedProposer {
                     Ok(block) => {
                         let cid = *block.header.cid();
                         let msg_cnt = block.secpk_messages.len() + block.bls_messages.len();
-                        match submitter.submit_block(block).await {
+                        match submitter.submit_blocks(vec![block]).await {
                             Ok(()) => info!("Proposed block {} with {} messages", cid, msg_cnt),
                             Err(e) => error!("Failed to submit block: {}", e),
                         }

--- a/blockchain/consensus/deleg_cns/src/proposer.rs
+++ b/blockchain/consensus/deleg_cns/src/proposer.rs
@@ -13,7 +13,10 @@ use std::{collections::HashMap, sync::Arc};
 
 use forest_blocks::{BlockHeader, GossipBlock, Tipset};
 use forest_chain::Scale;
-use forest_chain_sync::consensus::{MessagePoolApi, Proposer, SyncGossipSubmitter};
+use forest_chain_sync::{
+    consensus::{MessagePoolApi, Proposer, SyncGossipSubmitter},
+    WorkerState,
+};
 use forest_ipld_blockstore::BlockStore;
 use forest_key_management::Key;
 use forest_networks::Height;
@@ -104,6 +107,7 @@ impl Proposer for DelegatedProposer {
         state_manager: Arc<StateManager<DB>>,
         mpool: Arc<MP>,
         submitter: SyncGossipSubmitter,
+        _sync_state: WorkerState,
     ) -> anyhow::Result<Vec<JoinHandle<()>>>
     where
         DB: BlockStore + Sync + Send + 'static,

--- a/blockchain/consensus/fil_cns/src/composition.rs
+++ b/blockchain/consensus/fil_cns/src/composition.rs
@@ -15,6 +15,7 @@ type MiningTask = JoinHandle<()>;
 pub type FullConsensus = FilecoinConsensus<DrandBeacon, FullVerifier>;
 
 pub const FETCH_PARAMS: bool = true;
+pub const PUBLISH_MSG: bool = true;
 
 pub fn reward_calc() -> Arc<dyn forest_interpreter::RewardCalc> {
     Arc::new(forest_interpreter::RewardActorMessageCalc)

--- a/blockchain/consensus/fil_cns/src/composition.rs
+++ b/blockchain/consensus/fil_cns/src/composition.rs
@@ -3,7 +3,10 @@
 use crate::FilecoinConsensus;
 use async_std::{sync::RwLock, task::JoinHandle};
 use forest_beacon::DrandBeacon;
-use forest_chain_sync::consensus::{MessagePoolApi, SyncGossipSubmitter};
+use forest_chain_sync::{
+    consensus::{MessagePoolApi, SyncGossipSubmitter},
+    WorkerState,
+};
 use forest_fil_types::verifier::FullVerifier;
 use forest_ipld_blockstore::BlockStore;
 use forest_key_management::KeyStore;
@@ -26,6 +29,7 @@ pub async fn consensus<DB, MP>(
     _keystore: &Arc<RwLock<KeyStore>>,
     _mpool: &Arc<MP>,
     _submitter: SyncGossipSubmitter,
+    _sync_state: WorkerState,
 ) -> anyhow::Result<(FullConsensus, Vec<MiningTask>)>
 where
     DB: BlockStore + Send + Sync + 'static,

--- a/blockchain/consensus/fil_cns/src/lib.rs
+++ b/blockchain/consensus/fil_cns/src/lib.rs
@@ -122,4 +122,8 @@ where
     {
         validation::validate_block::<_, _, V>(state_manager, self.beacon.clone(), block).await
     }
+
+    fn requires_block_signature() -> bool {
+        true
+    }
 }

--- a/blockchain/consensus/fil_cns/src/lib.rs
+++ b/blockchain/consensus/fil_cns/src/lib.rs
@@ -112,6 +112,10 @@ where
 {
     type Error = FilecoinConsensusError;
 
+    const REQUIRE_MINER_SIGNATURE: bool = true;
+    const ENFORCE_EPOCH_DELAY: bool = true;
+    const ENFORCE_BLOCK_GAS_LIMIT: bool = true;
+
     async fn validate_block<DB>(
         &self,
         state_manager: Arc<StateManager<DB>>,
@@ -121,13 +125,5 @@ where
         DB: BlockStore + Sync + Send + 'static,
     {
         validation::validate_block::<_, _, V>(state_manager, self.beacon.clone(), block).await
-    }
-
-    fn requires_block_signature() -> bool {
-        true
-    }
-
-    fn time_based_epoch() -> bool {
-        true
     }
 }

--- a/blockchain/consensus/fil_cns/src/lib.rs
+++ b/blockchain/consensus/fil_cns/src/lib.rs
@@ -126,4 +126,8 @@ where
     fn requires_block_signature() -> bool {
         true
     }
+
+    fn time_based_epoch() -> bool {
+        true
+    }
 }

--- a/blockchain/consensus/narwhal_cns/src/composition.rs
+++ b/blockchain/consensus/narwhal_cns/src/composition.rs
@@ -15,9 +15,9 @@ type MiningTask = JoinHandle<anyhow::Result<()>>;
 pub type FullConsensus = NarwhalConsensus;
 
 pub const FETCH_PARAMS: bool = false;
+pub const PUBLISH_MSG: bool = false;
 
 // TODO: Disable block gossiping.
-// TODO: Disable mempool gossiping.
 
 // Only give reward for gas. There can be as many blocks as validators in each round.
 pub fn reward_calc() -> Arc<dyn forest_interpreter::RewardCalc> {

--- a/blockchain/consensus/narwhal_cns/src/composition.rs
+++ b/blockchain/consensus/narwhal_cns/src/composition.rs
@@ -1,7 +1,10 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 use async_std::{sync::RwLock, task::JoinHandle};
-use forest_chain_sync::consensus::{MessagePoolApi, SyncGossipSubmitter};
+use forest_chain_sync::{
+    consensus::{MessagePoolApi, SyncGossipSubmitter},
+    WorkerState,
+};
 use forest_ipld_blockstore::BlockStore;
 use forest_key_management::KeyStore;
 use forest_state_manager::StateManager;
@@ -31,6 +34,7 @@ pub async fn consensus<DB, MP>(
     _keystore: &Arc<RwLock<KeyStore>>,
     _mpool: &Arc<MP>,
     _submitter: SyncGossipSubmitter,
+    _sync_state: WorkerState,
 ) -> anyhow::Result<(FullConsensus, Vec<MiningTask>)>
 where
     DB: BlockStore + Send + Sync + 'static,

--- a/blockchain/consensus/narwhal_cns/src/consensus.rs
+++ b/blockchain/consensus/narwhal_cns/src/consensus.rs
@@ -76,14 +76,15 @@ impl Consensus for NarwhalConsensus {
 
     /// We cannot sign because each validator has to derive the same blocks from the total ordering
     /// provided by Narwhal and Bullshark.
-    fn requires_block_signature() -> bool {
-        false
-    }
+    const REQUIRE_MINER_SIGNATURE: bool = false;
 
     /// Narwhal doesn't indicate the passage of time. While we could estimate the maximum chain growth,
     /// it can only be used if we know how many validators were present in each committee. And the actual
     /// growth can be much less than that, so it's not possible to compare against the wall clock time.
-    fn time_based_epoch() -> bool {
-        false
-    }
+    const ENFORCE_EPOCH_DELAY: bool = false;
+
+    /// We cannot enforce the block gas limit because we put all batches in a certificate into a single block,
+    /// using the certificate authority as the miner ID, and we put all certificates at the same round into
+    /// the same Tipset. Since a Tipset requires unique miners, we can't split blocks of the same miner.
+    const ENFORCE_BLOCK_GAS_LIMIT: bool = false;
 }

--- a/blockchain/consensus/narwhal_cns/src/consensus.rs
+++ b/blockchain/consensus/narwhal_cns/src/consensus.rs
@@ -73,4 +73,8 @@ impl Consensus for NarwhalConsensus {
         // apply them, as long as our chain ends up with the block we sampled.
         Ok(())
     }
+
+    fn requires_block_signature() -> bool {
+        false
+    }
 }

--- a/blockchain/consensus/narwhal_cns/src/consensus.rs
+++ b/blockchain/consensus/narwhal_cns/src/consensus.rs
@@ -74,7 +74,16 @@ impl Consensus for NarwhalConsensus {
         Ok(())
     }
 
+    /// We cannot sign because each validator has to derive the same blocks from the total ordering
+    /// provided by Narwhal and Bullshark.
     fn requires_block_signature() -> bool {
+        false
+    }
+
+    /// Narwhal doesn't indicate the passage of time. While we could estimate the maximum chain growth,
+    /// it can only be used if we know how many validators were present in each committee. And the actual
+    /// growth can be much less than that, so it's not possible to compare against the wall clock time.
+    fn time_based_epoch() -> bool {
         false
     }
 }

--- a/blockchain/consensus/narwhal_cns/src/exec.rs
+++ b/blockchain/consensus/narwhal_cns/src/exec.rs
@@ -1,8 +1,11 @@
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
 };
 
 use crate::consensus::NarwhalConsensusError;
@@ -11,6 +14,7 @@ use async_trait::async_trait;
 use forest_blocks::{Error as BlockchainError, Ticket, Tipset};
 use forest_chain::ChainStore;
 use forest_chain::Error as ChainStoreError;
+use forest_chain_sync::{SyncStage, WorkerState};
 use forest_crypto::VRFProof;
 use forest_encoding::tuple::*;
 use forest_ipld_blockstore::BlockStore;
@@ -27,18 +31,37 @@ pub struct NarwhalOutput {
 }
 
 pub struct NarwhalExecutionState<BS> {
+    sync_state: WorkerState,
     chain_store: Arc<ChainStore<BS>>,
     output_tx: Sender<NarwhalOutput>,
     locked: AtomicBool,
 }
 
 impl<BS> NarwhalExecutionState<BS> {
-    pub fn new(chain_store: Arc<ChainStore<BS>>, output_tx: Sender<NarwhalOutput>) -> Self {
+    pub fn new(
+        sync_state: WorkerState,
+        chain_store: Arc<ChainStore<BS>>,
+        output_tx: Sender<NarwhalOutput>,
+    ) -> Self {
         Self {
+            sync_state,
             chain_store,
             output_tx,
             locked: AtomicBool::new(false),
         }
+    }
+
+    async fn wait_for_sync(&self) {
+        loop {
+            if self.is_sync_complete().await {
+                return;
+            }
+            async_std::task::sleep(Duration::from_secs(1)).await;
+        }
+    }
+
+    async fn is_sync_complete(&self) -> bool {
+        self.sync_state.read().await.stage() == SyncStage::Complete
     }
 }
 
@@ -70,6 +93,10 @@ where
 {
     /// Load the tip of the chain and get the last certificate index from the `Ticket` in the header.
     async fn load_next_certificate_index(&self) -> Result<SequenceNumber, Self::Error> {
+        // Don't return where to replay from until we have received what we could from the chan sync,
+        // otherwise we might be asking for a replay of garbage collected data because we are behind.
+        self.wait_for_sync().await;
+
         match self.chain_store.heaviest_tipset().await {
             None => Ok(0),
             Some(tipset) => {

--- a/blockchain/consensus/narwhal_cns/src/exec.rs
+++ b/blockchain/consensus/narwhal_cns/src/exec.rs
@@ -115,7 +115,7 @@ pub struct ConsensusTransactionIndex {
 }
 
 impl ConsensusTransactionIndex {
-    fn next_consensus_index(&self) -> SequenceNumber {
+    pub fn next_consensus_index(&self) -> SequenceNumber {
         if self.transactions_included < self.transactions_total {
             self.consensus_index
         } else {

--- a/blockchain/consensus/narwhal_cns/src/proposer.rs
+++ b/blockchain/consensus/narwhal_cns/src/proposer.rs
@@ -205,6 +205,14 @@ where
             Ok(output) => output,
         };
 
+        // Check that the next certificate can actually be appended to the next head.
+        let head_index = ConsensusTransactionIndex::try_from(next_head.as_ref())?;
+        if head_index.next_consensus_index() > next_output.consensus_output.consensus_index {
+            // It looks like maybe we got a block from a peer during historical catch up that already
+            // includes this output, and we should not turn it into a duplicate block.
+            continue;
+        }
+
         // TODO: We might have to create multiple blocks from the same batch to respect limits!
         // For that, we should bite off just enough messages to be within limits, then keep the
         // partially consumed output in a buffer until we manage to append the block.

--- a/blockchain/consensus/narwhal_cns/src/proposer.rs
+++ b/blockchain/consensus/narwhal_cns/src/proposer.rs
@@ -186,6 +186,9 @@ async fn handle_head_changes<DB>(
 where
     DB: BlockStore + Sync + Send + 'static,
 {
+    // We need to buffer the first output from the next round, so we can put multiple into the same tipset.
+    let mut output_buffer: Vec<NarwhalOutput> = Vec::new();
+
     loop {
         // Wait for the next chain extension.
         let next_head = if let Some(tipset) = current_head.take() {
@@ -206,34 +209,79 @@ where
         // Notify the mempool polling process that there's a new tip.
         head_tx.send_replace(Some(next_head.clone()));
 
-        // Take the next certificate from the queue and turn it into a block, then submit.
-        let next_output = match output_rx.recv().await {
-            Err(_) => return Err(anyhow!("Cannot receive Narwhal output!")),
-            Ok(output) => output,
-        };
-
         // Check that the next certificate can actually be appended to the next head.
         let head_index = ConsensusTransactionIndex::try_from(next_head.as_ref())?;
-        if head_index.next_consensus_index() > next_output.consensus_output.consensus_index {
-            // It looks like maybe we got a block from a peer during historical catch up that already
-            // includes this output, and we should not turn it into a duplicate block.
-            continue;
+
+        // Take all certificates for the next round, so they can be turned into a single tipset.
+        let mut next_outputs = Vec::new();
+        loop {
+            // There will always be a next output within some max delay.
+            let next_output = recv_output(&output_rx).await?;
+
+            if head_index.next_consensus_index() > next_output.consensus_output.consensus_index {
+                // It looks like maybe we got a block from a peer during historical catch up that already
+                // includes this output, and we should not turn it into a duplicate block.
+                continue;
+            }
+
+            // Try to extend the current buffer, or start a new one when we can't.
+            if output_buffer
+                .last()
+                .map(|o| o.epoch_round() == next_output.epoch_round())
+                .unwrap_or_default()
+            {
+                output_buffer.push(next_output);
+            } else {
+                std::mem::swap(&mut output_buffer, &mut next_outputs);
+                output_buffer.push(next_output);
+                break;
+            }
         }
 
-        // TODO: We might have to create multiple blocks from the same batch to respect limits!
-        // For that, we should bite off just enough messages to be within limits, then keep the
-        // partially consumed output in a buffer until we manage to append the block.
-        let block = create_block_from_output(
+        let blocks = create_blocks_from_outputs(
             &state_manager,
             &validator_addresses,
             &next_head,
-            next_output,
+            next_outputs,
         )
         .await?;
 
         // Enqueue appending to the local blockchain.
-        submitter.submit_block_locally(block).await?;
+        submitter.submit_blocks_locally(blocks).await?;
     }
+}
+
+async fn recv_output(output_rx: &Receiver<NarwhalOutput>) -> anyhow::Result<NarwhalOutput> {
+    match output_rx.recv().await {
+        Err(e) => Err(anyhow!("Cannot receive Narwhal output: {}", e)),
+        Ok(output) => Ok(output),
+    }
+}
+
+/// Create blocks from outputs in the same epoch+round, using the same base as their parent,
+/// to form a single tipset.
+async fn create_blocks_from_outputs<DB>(
+    state_manager: &Arc<StateManager<DB>>,
+    validator_addresses: &HashMap<PublicKey, Address>,
+    base: &Arc<Tipset>,
+    outputs: Vec<NarwhalOutput>,
+) -> anyhow::Result<Vec<GossipBlock>>
+where
+    DB: BlockStore + Sync + Send + 'static,
+{
+    let mut blocks = Vec::new();
+
+    for output in outputs {
+        // TODO: We might have to create multiple blocks from the same batch to respect limits!
+        // For that, we should bite off just enough messages to be within limits, then keep the
+        // partially consumed output in a buffer until we manage to append the block.
+        // Unfortunately that would not work because a Tipset requires all miners in it to be unique.
+        blocks.push(
+            create_block_from_output(state_manager, validator_addresses, base, output).await?,
+        );
+    }
+
+    Ok(blocks)
 }
 
 /// Create a block from a Narwhal certificate and the included batches of transactions.


### PR DESCRIPTION
Continuing from Part 1: https://github.com/aakoshh/forest/pull/4 

Part 2:

Model changes:
- [x] Disable signature check in the common validations
- [ ] ~~Split batches among multiple blocks so that no limits are violated.~~
- [x] Group all blocks within the same Narwhal round to appear under the same epoch. _For this they would have to be in the same tipset, for which they will need to be mined by different miners. That might be true if every Narwhal authority can only produce one certificate per round. It would fail if we had to split blocks due to block limits._
- [x] Disable gas limit during execution. _Required for miner uniqueness in tipsets._
- [ ] Check how Narwhal/Bullshark handles round mismatches between authorities, assess the impact on epochs.
- [x] Disable Mempool gossiping
- [x] Find a way to evaluate network head when there are no blocks being gossiped. _It can pick it up from the `HelloMessage` but then it is vulnerable to the adversary lying about the epoch, and the node dropping all other hellos received, never to see one again._
- [x] Enable historical chain sync during startup so latecomers can join. _This will happen automatically after network head evaludation, and it's based on request/response pattern, asking for ranges of blocks, not gossip. We have to assume honest parties for it to work._
- [x] Disable chain sync following other nodes. _What will happen is that we evaluate the network head and bootstrap, then go back to evaluating the network head again, but there are no more hello messages coming, and we're not gossiping blocks, so it stays in that loop. Until there are enough new connections with new hellos, which is when we do another bootstrap. If for any reason it goes into Follow mode, again there won't be any blocks gossiped. If all nodes are honest, that is._
- [x] Deal with the case where we have to do historical catch up before replay can be attempted. Can we delay starting the proposer until the historical catch up is over? _`ChainMuxer::sync_state_cloned()` looks promising._
- [x] Deal with the case where historical catch up kicks in again while replay is running and the replayed consensus index is not what can be added to the last block; in this case just skip the batch
- [ ] Allow invalid and duplicate transactions during block processing
- [x] Disable epoch validation in terms of block delay and wall clock time
- [ ] Some kind of reset mechanism for account and nonce pairs that never get included; maybe their batches got bypassed in Narwhal.
- [ ] Pull new code from Narwhal because the current one doesn't do replay (they are in the middle of refactoring)
- [ ] Create signatures over the blocks and gossip them independently of the blocks. Store them associated with the blocks when received of the network. When a quorum is reached the block is final.
- [ ] The historical block exchange protocol should be extended to allow requesting signatures.

Config additions:
- [ ] Add a committee public key to miner ID association in the config.
- [ ] Read committee config from a file.
- [ ] Read the committee-miner association from a file.
- [ ] Read config location from an env var.
- [ ] Compose consensus and proposer


**Caveats**:
* The chain sync assumes 100% honest peers